### PR TITLE
Bug fix for longitudinal/meridional calculation

### DIFF
--- a/fluidsf/calculate_structure_function.py
+++ b/fluidsf/calculate_structure_function.py
@@ -116,7 +116,7 @@ def calculate_structure_function(  # noqa: D417, C901
                 + (inputs["adv_y_" + direction + "_shift"] - adv_y)
                 * (inputs["v_" + direction + "_shift"] - v)
             )
-            if traditional_type is not None:
+            if traditional_type is not None and direction == "x":
                 if any("LL" in t for t in traditional_type):
                     SF_dict["SF_LL_" + direction] = np.nanmean(
                         (inputs["u_" + direction + "_shift"] - u) ** 2
@@ -126,27 +126,41 @@ def calculate_structure_function(  # noqa: D417, C901
                         (inputs["u_" + direction + "_shift"] - u) ** 3
                     )
                 if any("LTT" in t for t in traditional_type):
-                    if direction == "x":
-                        SF_dict["SF_LTT_" + direction] = np.nanmean(
-                            (inputs["u_" + direction + "_shift"] - u)
-                            * (inputs["v_" + direction + "_shift"] - v) ** 2
-                        )
+                    SF_dict["SF_LTT_" + direction] = np.nanmean(
+                        (inputs["u_" + direction + "_shift"] - u)
+                        * (inputs["v_" + direction + "_shift"] - v) ** 2
+                    )
 
-                    if direction == "y":
-                        SF_dict["SF_LTT_" + direction] = np.nanmean(
-                            (inputs["v_" + direction + "_shift"] - v)
-                            * (inputs["u_" + direction + "_shift"] - u) ** 2
-                        )
+            elif traditional_type is not None and direction == "y":
+                if any("LL" in t for t in traditional_type):
+                    SF_dict["SF_LL_" + direction] = np.nanmean(
+                        (inputs["v_" + direction + "_shift"] - v) ** 2
+                    )
+                if any("LLL" in t for t in traditional_type):
+                    SF_dict["SF_LLL_" + direction] = np.nanmean(
+                        (inputs["v_" + direction + "_shift"] - v) ** 3
+                    )
+                if any("LTT" in t for t in traditional_type):
+                    SF_dict["SF_LTT_" + direction] = np.nanmean(
+                        (inputs["v_" + direction + "_shift"] - v)
+                        * (inputs["u_" + direction + "_shift"] - u) ** 2
+                    )
 
         if scalar is not None:
             SF_dict["SF_scalar_" + direction] = np.nanmean(
                 (inputs["adv_scalar_" + direction + "_shift"] - adv_scalar)
                 * (inputs["scalar_" + direction + "_shift"] - scalar)
             )
-            if traditional_type is not None:
+            if traditional_type is not None and direction == "x":
                 if any("LSS" in t for t in traditional_type):
                     SF_dict["SF_LSS_" + direction] = np.nanmean(
                         (inputs["u_" + direction + "_shift"] - u)
+                        * (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
+                    )
+            elif traditional_type is not None and direction == "y":
+                if any("LSS" in t for t in traditional_type):
+                    SF_dict["SF_LSS_" + direction] = np.nanmean(
+                        (inputs["v_" + direction + "_shift"] - v)
                         * (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                     )
     return SF_dict

--- a/tests/test_calculate_structure_function.py
+++ b/tests/test_calculate_structure_function.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import numpy as np
 import pytest
 
@@ -49,7 +47,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
                 "SF_LL_x": 1,
                 "SF_scalar_x": 5,
                 "SF_velocity_y": 138,
-                "SF_LL_y": 4,
+                "SF_LL_y": 26,
                 "SF_scalar_y": 8,
             },
         ),
@@ -127,7 +125,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
                 "SF_LL_x": 1,
                 "SF_scalar_x": 5,
                 "SF_velocity_y": 138,
-                "SF_LL_y": 4,
+                "SF_LL_y": 26,
                 "SF_scalar_y": 8,
             },
         ),
@@ -198,4 +196,14 @@ def test_calculate_structure_function_parameterized(
         boundary,
     )
 
-    TestCase().assertDictEqual(output_dict, expected_result)
+    for key, value in expected_result.items():
+        if key in output_dict:
+            if not np.allclose(output_dict[key], value):
+                print(output_dict[key])
+                print(expected_result[key])
+                raise AssertionError(
+                    f"Output dict value for key '{key}' does not match "
+                    f"expected value '{output_dict[key]}'."
+                )
+        else:
+            raise AssertionError(f"Output dict does not contain key '{key}'.")

--- a/tests/test_generate_structure_functions.py
+++ b/tests/test_generate_structure_functions.py
@@ -43,14 +43,14 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_LLL_y": np.array(
                     [
                         0,
-                        -1000,
                         -8000,
-                        -27000,
                         -64000,
-                        -125000,
                         -216000,
-                        -343000,
                         -512000,
+                        -1000000,
+                        -1728000,
+                        -2744000,
+                        -4096000,
                     ]
                 ),
                 "SF_LTT_x": np.array(
@@ -75,14 +75,14 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_LSS_y": np.array(
                     [
                         0,
-                        -9000,
-                        -72000,
-                        -243000,
-                        -576000,
-                        -1125000,
-                        -1944000,
-                        -3087000,
-                        -4608000,
+                        -18000,
+                        -144000,
+                        -486000,
+                        -1152000,
+                        -2250000,
+                        -3888000,
+                        -6174000,
+                        -9216000,
                     ]
                 ),
                 "x-diffs": np.linspace(0, 8, 9),
@@ -113,11 +113,11 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
                 "SF_advection_scalar_y": np.array([0, 170100, 302400, 396900, 453600]),
                 "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
-                "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
+                "SF_LLL_y": np.array([0, 576000, 768000, 672000, 384000]),
                 "SF_LTT_x": np.array([0, 288, 384, 336, 192]),
                 "SF_LTT_y": np.array([0, 144000, 192000, 168000, 96000]),
                 "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
-                "SF_LSS_y": np.array([0, 648000, 864000, 756000, 432000]),
+                "SF_LSS_y": np.array([0, 1296000, 1728000, 1512000, 864000]),
                 "x-diffs": np.linspace(0, 4, 5),
                 "y-diffs": np.linspace(0, 4, 5),
             },  # expected_dict
@@ -157,14 +157,14 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_LLL_y": np.array(
                     [
                         0,
-                        -1000,
                         -8000,
-                        -27000,
                         -64000,
-                        -125000,
                         -216000,
-                        -343000,
                         -512000,
+                        -1000000,
+                        -1728000,
+                        -2744000,
+                        -4096000,
                     ]
                 ),
                 "SF_LTT_x": np.array(
@@ -189,14 +189,14 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_LSS_y": np.array(
                     [
                         0,
-                        -9000,
-                        -72000,
-                        -243000,
-                        -576000,
-                        -1125000,
-                        -1944000,
-                        -3087000,
-                        -4608000,
+                        -18000,
+                        -144000,
+                        -486000,
+                        -1152000,
+                        -2250000,
+                        -3888000,
+                        -6174000,
+                        -9216000,
                     ]
                 ),
                 "x-diffs": np.array(
@@ -251,9 +251,9 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_advection_scalar_x": np.array([0, 1701, 3024, 3969, 4536]),
                 "SF_advection_scalar_y": np.array([0, 170100, 302400, 396900, 453600]),
                 "SF_LLL_x": np.array([0, 72, 96, 84, 48]),
-                "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
+                "SF_LLL_y": np.array([0, 576000, 768000, 672000, 384000]),
                 "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
-                "SF_LSS_y": np.array([0, 648000, 864000, 756000, 432000]),
+                "SF_LSS_y": np.array([0, 1296000, 1728000, 1512000, 864000]),
                 "x-diffs": np.array(
                     [
                         0.0,
@@ -298,9 +298,9 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_advection_scalar_x": np.array([315, 3150, 9387]),
                 "SF_advection_scalar_y": np.array([31500, 315000, 938700]),
                 "SF_LLL_x": np.array([-3, -72, -357]),
-                "SF_LLL_y": np.array([-3000, -72000, -357000]),
+                "SF_LLL_y": np.array([-24000, -576000, -2856000]),
                 "SF_LSS_x": np.array([-27, -648, -3213]),
-                "SF_LSS_y": np.array([-27000, -648000, -3213000]),
+                "SF_LSS_y": np.array([-54000, -1296000, -6426000]),
                 "x-diffs": np.array([1, 4, 7]),
                 "y-diffs": np.array([1, 4, 7]),
             },  # expected_dict
@@ -329,15 +329,9 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_advection_scalar_x": np.array([315, 3150, 9387]),
                 "SF_advection_scalar_y": np.array([31500, 315000, 938700]),
                 "SF_LLL_x": np.array([-3, -72, -357]),
-                "SF_LLL_y": np.array([-3000, -72000, -357000]),
+                "SF_LLL_y": np.array([-24000, -576000, -2856000]),
                 "SF_LSS_x": np.array([-27, -648, -3213]),
-                "SF_LSS_y": np.array(
-                    [
-                        -27000,
-                        -648000,
-                        -3213000,
-                    ]
-                ),
+                "SF_LSS_y": np.array([-54000, -1296000, -6426000]),
                 "x-diffs": np.array(
                     [111195.08372419, 444780.33489677, 778365.58606934]
                 ),
@@ -374,9 +368,9 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                     [1237.5, 16087.5, 39600.0, 75487.5, 139837.5]
                 ),
                 "SF_LLL_x": np.array([0, -1, -8, -27]),
-                "SF_LLL_y": np.array([-62.5, -2187.5, -8000.0, -21312.5, -53437.5]),
+                "SF_LLL_y": np.array([-500, -17500, -64000, -170500, -427500]),
                 "SF_LSS_x": np.array([0, -9, -72, -243]),
-                "SF_LSS_y": np.array([-562.5, -19687.5, -72000, -191812.5, -480937.5]),
+                "SF_LSS_y": np.array([-1125, -39375, -144000, -383625, -961875]),
                 "x-diffs": np.linspace(0, 3, 4),
                 "y-diffs": np.array([0.5, 2.5, 4, 5.5, 7.5]),
             },  # expected_dict
@@ -412,28 +406,28 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 "SF_LLL_y": np.array(
                     [
                         0,
-                        -1000,
                         -8000,
-                        -27000,
                         -64000,
-                        -125000,
                         -216000,
-                        -343000,
                         -512000,
+                        -1000000,
+                        -1728000,
+                        -2744000,
+                        -4096000,
                     ]
                 ),
                 "SF_LSS_x": np.array([0, 648, 864, 756, 432]),
                 "SF_LSS_y": np.array(
                     [
                         0,
-                        -9000,
-                        -72000,
-                        -243000,
-                        -576000,
-                        -1125000,
-                        -1944000,
-                        -3087000,
-                        -4608000,
+                        -18000,
+                        -144000,
+                        -486000,
+                        -1152000,
+                        -2250000,
+                        -3888000,
+                        -6174000,
+                        -9216000,
                     ]
                 ),
                 "x-diffs": np.linspace(0, 4, 5),
@@ -468,11 +462,11 @@ from fluidsf.generate_structure_functions import generate_structure_functions
                 ),
                 "SF_advection_scalar_y": np.array([0, 170100, 302400, 396900, 453600]),
                 "SF_LLL_x": np.array([0, -1, -8, -27, -64, -125, -216, -343, -512]),
-                "SF_LLL_y": np.array([0, 72000, 96000, 84000, 48000]),
+                "SF_LLL_y": np.array([0, 576000, 768000, 672000, 384000]),
                 "SF_LSS_x": np.array(
                     [0, -9, -72, -243, -576, -1125, -1944, -3087, -4608]
                 ),
-                "SF_LSS_y": np.array([0, 648000, 864000, 756000, 432000]),
+                "SF_LSS_y": np.array([0, 1296000, 1728000, 1512000, 864000]),
                 "x-diffs": np.linspace(0, 8, 9),
                 "y-diffs": np.linspace(0, 4, 5),
             },  # expected_dict


### PR DESCRIPTION
This PR fixes a bug where LL, LLL and LSS (all longitudinal structure functions except LTT) use ``u`` as the longitudinal velocity and ``v`` as the transverse velocity, even when the separation is in the y-direction. 

This PR corrects the core code to use the correct velocity components for meridional separations. @cassidymwagner could you assist in correcting the tests where needed! 

UPDATE: I merged it into the 2D map branch, and it matches the 2D map calculations, so I think the calculation itself is correct. Just the tests that may need updating.