### PR TITLE
Bug fix for 3D transverse velocity calculation

### DIFF
--- a/fluidsf/calculate_structure_function_3d.py
+++ b/fluidsf/calculate_structure_function_3d.py
@@ -148,8 +148,10 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LTT" in t for t in sf_type):
                 SF_dict["SF_LTT_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u)
-                    * ( (inputs["v_" + direction + "_shift"] - v) ** 2
-                       + (inputs["w_" + direction + "_shift"] - w) ** 2)
+                    * (
+                        (inputs["v_" + direction + "_shift"] - v) ** 2
+                        + (inputs["w_" + direction + "_shift"] - w) ** 2
+                    )
                 )
             if any("LSS" in t for t in sf_type):
                 SF_dict["SF_LSS_" + direction] = np.nanmean(
@@ -169,8 +171,10 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LTT" in t for t in sf_type):
                 SF_dict["SF_LTT_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v)
-                    * ((inputs["u_" + direction + "_shift"] - u) ** 2
-                       + (inputs["w_" + direction + "_shift"] - w) ** 2)
+                    * (
+                        (inputs["u_" + direction + "_shift"] - u) ** 2
+                        + (inputs["w_" + direction + "_shift"] - w) ** 2
+                    )
                 )
             if any("LSS" in t for t in sf_type):
                 SF_dict["SF_LSS_" + direction] = np.nanmean(
@@ -190,8 +194,10 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LTT" in t for t in sf_type):
                 SF_dict["SF_LTT_" + direction] = np.nanmean(
                     (inputs["w_" + direction + "_shift"] - w)
-                    * ((inputs["u_" + direction + "_shift"] - u) ** 2
-                       + (inputs["v_" + direction + "_shift"] - v) ** 2)
+                    * (
+                        (inputs["u_" + direction + "_shift"] - u) ** 2
+                        + (inputs["v_" + direction + "_shift"] - v) ** 2
+                    )
                 )
             if any("LSS" in t for t in sf_type):
                 SF_dict["SF_LSS_" + direction] = np.nanmean(

--- a/fluidsf/calculate_structure_function_3d.py
+++ b/fluidsf/calculate_structure_function_3d.py
@@ -148,7 +148,8 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LTT" in t for t in sf_type):
                 SF_dict["SF_LTT_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u)
-                    * (inputs["v_" + direction + "_shift"] - v) ** 2
+                    * ( (inputs["v_" + direction + "_shift"] - v) ** 2
+                       + (inputs["w_" + direction + "_shift"] - w) ** 2)
                 )
             if any("LSS" in t for t in sf_type):
                 SF_dict["SF_LSS_" + direction] = np.nanmean(
@@ -168,7 +169,8 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LTT" in t for t in sf_type):
                 SF_dict["SF_LTT_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v)
-                    * (inputs["u_" + direction + "_shift"] - u) ** 2
+                    * ((inputs["u_" + direction + "_shift"] - u) ** 2
+                       + (inputs["w_" + direction + "_shift"] - w) ** 2)
                 )
             if any("LSS" in t for t in sf_type):
                 SF_dict["SF_LSS_" + direction] = np.nanmean(
@@ -188,7 +190,8 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LTT" in t for t in sf_type):
                 SF_dict["SF_LTT_" + direction] = np.nanmean(
                     (inputs["w_" + direction + "_shift"] - w)
-                    * (inputs["u_" + direction + "_shift"] - u) ** 2
+                    * ((inputs["u_" + direction + "_shift"] - u) ** 2
+                       + (inputs["v_" + direction + "_shift"] - v) ** 2)
                 )
             if any("LSS" in t for t in sf_type):
                 SF_dict["SF_LSS_" + direction] = np.nanmean(

--- a/tests/test_calculate_structure_function_3d.py
+++ b/tests/test_calculate_structure_function_3d.py
@@ -178,7 +178,7 @@ from fluidsf.calculate_structure_function_3d import calculate_structure_function
                 "SF_advection_velocity_y": 3 * (1) ** 2,
                 "SF_LL_y": 1 * (1) ** 2,
                 "SF_LLL_y": 1 * (1) ** 3,
-                "SF_LTT_y": 1 * (1) ** 3,
+                "SF_LTT_y": 2 * (1) ** 3,
                 "SF_advection_velocity_z": 0,
                 "SF_LL_z": 0,
                 "SF_LLL_z": 0,

--- a/tests/test_generate_structure_functions_3d.py
+++ b/tests/test_generate_structure_functions_3d.py
@@ -108,7 +108,7 @@ from fluidsf.generate_structure_functions_3d import generate_structure_functions
                 "SF_LSS_y": 1 * np.linspace(0, 8, 9) ** 3,
                 "SF_LSS_z": 0 * np.linspace(0, 8, 9),
                 "SF_LTT_x": 0 * np.linspace(0, 8, 9),
-                "SF_LTT_y": 1 * np.linspace(0, 8, 9) ** 3,
+                "SF_LTT_y": 2 * np.linspace(0, 8, 9) ** 3,
                 "SF_LTT_z": 0 * np.linspace(0, 8, 9),
                 "x-diffs": np.linspace(0, 8, 9),
                 "y-diffs": np.linspace(0, 8, 9),


### PR DESCRIPTION
The transverse velocity calculations for the 3D analysis was only including one component of the transverse velocity for each separation direction, but there are two components of transverse velocity in each case (i.e. $\mathbf{u_T}$ is a vector, not a scalar $u_T$ like the 2D and 1D cases.

This PR fixes the transverse calculation within the $SF_{LTT}$ calculations, which are now:

$$ SF_{LTT} =\overline{\delta u_L (\delta \mathbf{u_T} \cdot \delta \mathbf{u_T})}$$

where $\mathbf{u_T}$ is the component of the velocity that is perpendicular to the separation vector.

For example given a velocity field $\mathbf{u}=(u,v,w)$, if separation vectors are in the $x$-direction, then  $\mathbf{u_L}=(u,0,0)$, $\mathbf{u_T} = (0,v,w)$. The spatial differences are then $\delta \mathbf{u_T} = (0,\delta v,\delta w)$ and the above structure function can be calculated as $SF_{LTT} =\overline{\delta u (\delta v \delta v + \delta w \delta w)} $

