### PR TITLE
Add TT and SS structure functions to all modules

### DIFF
--- a/fluidsf/calculate_sf_maps_2d.py
+++ b/fluidsf/calculate_sf_maps_2d.py
@@ -41,7 +41,7 @@ def calculate_sf_maps_2d(  # noqa: D417, C901
             Shift amount for y shift.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V", "ASF_S", "LL", "LLL", "LTT", "LSS".
+            Accepted types are: "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS".
         scalar: ndarray, optional
             Array of scalar values. Defaults to None.
         adv_scalar: ndarray, optional
@@ -60,6 +60,8 @@ def calculate_sf_maps_2d(  # noqa: D417, C901
                 'SF_LL_xy': The traditional structure function LL for separation
                 vectors in the x-y plane.
                 'SF_TT_xy': The traditional structure function TT for separation
+                vectors in the x-y plane.
+                'SF_SS_xy': The traditional structure function SS for separation
                 vectors in the x-y plane.
                 'SF_LLL_xy': The traditional structure function LLL for separation
                 vectors in the x-y plane..
@@ -113,14 +115,14 @@ def calculate_sf_maps_2d(  # noqa: D417, C901
         cosine_angle = x_separation / np.sqrt(x_separation**2 + y_separation**2)
         sine_angle = y_separation / np.sqrt(x_separation**2 + y_separation**2)
 
-    if any("LL" in t for t in sf_type):
-        SF_dict["SF_LL_xy"] = np.nanmean(
-            (
-                (inputs["u_xy_shift"] - u) * cosine_angle
-                + (inputs["v_xy_shift"] - v) * sine_angle
+        if any("LL" in t for t in sf_type):
+            SF_dict["SF_LL_xy"] = np.nanmean(
+                (
+                    (inputs["u_xy_shift"] - u) * cosine_angle
+                    + (inputs["v_xy_shift"] - v) * sine_angle
+                )
+                ** 2
             )
-            ** 2
-        )
         if any("TT" in t for t in sf_type):
             SF_dict["SF_TT_xy"] = np.nanmean(
                 (
@@ -129,6 +131,10 @@ def calculate_sf_maps_2d(  # noqa: D417, C901
                 )
                 ** 2
             )
+        if any("SS" in t for t in sf_type):
+            SF_dict["SF_SS_xy"] = np.nanmean(
+                (inputs["scalar_xy_shift"] - scalar) ** 2 )
+            
         if any("LLL" in t for t in sf_type):
             SF_dict["SF_LLL_xy"] = np.nanmean(
                 (

--- a/fluidsf/calculate_sf_maps_2d.py
+++ b/fluidsf/calculate_sf_maps_2d.py
@@ -132,9 +132,8 @@ def calculate_sf_maps_2d(  # noqa: D417, C901
                 ** 2
             )
         if any("SS" in t for t in sf_type):
-            SF_dict["SF_SS_xy"] = np.nanmean(
-                (inputs["scalar_xy_shift"] - scalar) ** 2 )
-            
+            SF_dict["SF_SS_xy"] = np.nanmean((inputs["scalar_xy_shift"] - scalar) ** 2)
+
         if any("LLL" in t for t in sf_type):
             SF_dict["SF_LLL_xy"] = np.nanmean(
                 (

--- a/fluidsf/calculate_structure_function.py
+++ b/fluidsf/calculate_structure_function.py
@@ -35,7 +35,7 @@ def calculate_structure_function(  # noqa: D417, C901
             Shift amount for y shift.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V, "ASF_S", "LL", "LLL", "LTT", "LSS". Defaults to
+            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
             "ASF_V".
         scalar: ndarray, optional
             Array of scalar values. Defaults to None.
@@ -62,6 +62,10 @@ def calculate_structure_function(  # noqa: D417, C901
                 direction.
                 'SF_LL_x': The traditional structure function LL in the x direction.
                 'SF_LL_y': The traditional structure function LL in the y direction.
+                'SF_TT_x': The traditional structure function TT in the x direction.
+                'SF_TT_y': The traditional structure function TT in the y direction.
+                'SF_SS_x': The traditional structure function SS in the x direction.
+                'SF_SS_y': The traditional structure function SS in the y direction.
                 'SF_LLL_x': The traditional structure function LLL in the x direction.
                 'SF_LLL_y': The traditional structure function LLL in the y direction.
                 'SF_LTT_x': The traditional structure function LTT in the x direction.
@@ -114,6 +118,14 @@ def calculate_structure_function(  # noqa: D417, C901
                 SF_dict["SF_LL_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u) ** 2
                 )
+            if any("TT" in t for t in sf_type):
+                SF_dict["SF_TT_" + direction] = np.nanmean(
+                    (inputs["v_" + direction + "_shift"] - v) ** 2
+                )
+            if any("SS" in t for t in sf_type):
+                SF_dict["SF_SS_" + direction] = np.nanmean(
+                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
+                )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u) ** 3
@@ -133,6 +145,14 @@ def calculate_structure_function(  # noqa: D417, C901
             if any("LL" in t for t in sf_type):
                 SF_dict["SF_LL_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v) ** 2
+                )
+            if any("TT" in t for t in sf_type):
+                SF_dict["SF_TT_" + direction] = np.nanmean(
+                    (inputs["u_" + direction + "_shift"] - u) ** 2
+                )
+            if any("SS" in t for t in sf_type):
+                SF_dict["SF_SS_" + direction] = np.nanmean(
+                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                 )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(

--- a/fluidsf/calculate_structure_function.py
+++ b/fluidsf/calculate_structure_function.py
@@ -113,6 +113,11 @@ def calculate_structure_function(  # noqa: D417, C901
                 (inputs["adv_scalar_" + direction + "_shift"] - adv_scalar)
                 * (inputs["scalar_" + direction + "_shift"] - scalar)
             )
+        if any("SS" in t for t in sf_type):
+            SF_dict["SF_SS_" + direction] = np.nanmean(
+                (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
+            )
+                
         if direction == "x":
             if any("LL" in t for t in sf_type):
                 SF_dict["SF_LL_" + direction] = np.nanmean(
@@ -121,10 +126,6 @@ def calculate_structure_function(  # noqa: D417, C901
             if any("TT" in t for t in sf_type):
                 SF_dict["SF_TT_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v) ** 2
-                )
-            if any("SS" in t for t in sf_type):
-                SF_dict["SF_SS_" + direction] = np.nanmean(
-                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                 )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(
@@ -149,10 +150,6 @@ def calculate_structure_function(  # noqa: D417, C901
             if any("TT" in t for t in sf_type):
                 SF_dict["SF_TT_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u) ** 2
-                )
-            if any("SS" in t for t in sf_type):
-                SF_dict["SF_SS_" + direction] = np.nanmean(
-                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                 )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(

--- a/fluidsf/calculate_structure_function.py
+++ b/fluidsf/calculate_structure_function.py
@@ -35,8 +35,8 @@ def calculate_structure_function(  # noqa: D417, C901
             Shift amount for y shift.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
-            "ASF_V".
+            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS".
+            Defaults to "ASF_V".
         scalar: ndarray, optional
             Array of scalar values. Defaults to None.
         adv_scalar: ndarray, optional
@@ -117,7 +117,7 @@ def calculate_structure_function(  # noqa: D417, C901
             SF_dict["SF_SS_" + direction] = np.nanmean(
                 (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
             )
-                
+
         if direction == "x":
             if any("LL" in t for t in sf_type):
                 SF_dict["SF_LL_" + direction] = np.nanmean(

--- a/fluidsf/calculate_structure_function_1d.py
+++ b/fluidsf/calculate_structure_function_1d.py
@@ -25,8 +25,8 @@ def calculate_structure_function_1d(  # noqa: D417
             Array of separation distances.
         sf_type: list
             List of traditional structure function types to calculate.
-            Accepted types are: "LL", "LLL", "LTT", "LSS". Defaults to "LLL". If you
-            include "LSS", you must provide a 1D array for scalar.
+            Accepted types are: "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to "LLL". If you
+            include "SS" or "LSS", you must provide a 1D array for scalar.
         v: ndarray
             Array of v velocities. Defaults to None.
         scalar: ndarray, optional
@@ -42,6 +42,8 @@ def calculate_structure_function_1d(  # noqa: D417
             scalar structure functions (if applicable).
             The dictionary has the following keys:
                 'SF_LL': The second-order longitudinal velocity structure function.
+                'SF_TT': The second-order transverse velocity structure function.
+                'SF_SS': The second-order scalar structure function.
                 'SF_LLL': The third-order longitudinal velocity structure function.
                 'SF_LTT': The longitudinal-transverse velocity structure function.
                 'SF_LSS': The longitudinal-scalar structure function.
@@ -60,6 +62,10 @@ def calculate_structure_function_1d(  # noqa: D417
 
     if "LL" in sf_type:
         SF_dict["SF_LL"] = np.nanmean((inputs["u_shift"] - u) ** 2)
+    if "TT" in sf_type and v is not None:
+        SF_dict["SF_TT"] = np.nanmean((inputs["v_shift"] - v) ** 2)
+    if "SS" in sf_type and scalar is not None:
+        SF_dict["SF_SS"] = np.nanmean((inputs["scalar_shift"] - scalar) ** 2)
     if "LLL" in sf_type:
         SF_dict["SF_LLL"] = np.nanmean((inputs["u_shift"] - u) ** 3)
     if "LTT" in sf_type and v is not None:

--- a/fluidsf/calculate_structure_function_1d.py
+++ b/fluidsf/calculate_structure_function_1d.py
@@ -25,8 +25,8 @@ def calculate_structure_function_1d(  # noqa: D417
             Array of separation distances.
         sf_type: list
             List of traditional structure function types to calculate.
-            Accepted types are: "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to "LLL". If you
-            include "SS" or "LSS", you must provide a 1D array for scalar.
+            Accepted types are: "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
+            "LLL". If you include "SS" or "LSS", you must provide a 1D array for scalar.
         v: ndarray
             Array of v velocities. Defaults to None.
         scalar: ndarray, optional

--- a/fluidsf/calculate_structure_function_3d.py
+++ b/fluidsf/calculate_structure_function_3d.py
@@ -141,6 +141,10 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                 (inputs["adv_scalar_" + direction + "_shift"] - adv_scalar)
                 * (inputs["scalar_" + direction + "_shift"] - scalar)
             )
+        if any("SS" in t for t in sf_type):
+            SF_dict["SF_SS_" + direction] = np.nanmean(
+                (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
+            )
 
         if direction == "x":
             if any("LL" in t for t in sf_type):
@@ -151,10 +155,6 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                 SF_dict["SF_TT_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v) ** 2
                     + (inputs["w_" + direction + "_shift"] - w) ** 2
-                )
-            if any("SS" in t for t in sf_type):
-                SF_dict["SF_SS_" + direction] = np.nanmean(
-                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                 )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(
@@ -181,10 +181,6 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                     (inputs["u_" + direction + "_shift"] - u) ** 2
                     + (inputs["w_" + direction + "_shift"] - w) ** 2
                 )
-            if any("SS" in t for t in sf_type):
-                SF_dict["SF_SS_" + direction] = np.nanmean(
-                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
-                )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v) ** 3
@@ -209,10 +205,6 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                 SF_dict["SF_TT_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u) ** 2
                     + (inputs["v_" + direction + "_shift"] - v) ** 2
-                )
-            if any("SS" in t for t in sf_type):
-                SF_dict["SF_SS_" + direction] = np.nanmean(
-                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                 )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(

--- a/fluidsf/calculate_structure_function_3d.py
+++ b/fluidsf/calculate_structure_function_3d.py
@@ -44,8 +44,8 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             Shift amount for z shift.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
-            "ASF_V".
+            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS".
+            Defaults to "ASF_V".
         scalar: ndarray, optional
             Array of scalar values. Defaults to None.
         adv_scalar: ndarray, optional

--- a/fluidsf/calculate_structure_function_3d.py
+++ b/fluidsf/calculate_structure_function_3d.py
@@ -44,7 +44,7 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             Shift amount for z shift.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V, "ASF_S", "LL", "LLL", "LTT", "LSS". Defaults to
+            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
             "ASF_V".
         scalar: ndarray, optional
             Array of scalar values. Defaults to None.
@@ -76,6 +76,12 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                 'SF_LL_x': The traditional structure function LL in the x direction.
                 'SF_LL_y': The traditional structure function LL in the y direction.
                 'SF_LL_z': The traditional structure function LL in the z direction.
+                'SF_TT_x': The traditional structure function TT in the x direction.
+                'SF_TT_y': The traditional structure function TT in the y direction.
+                'SF_TT_z': The traditional structure function TT in the z direction.
+                'SF_SS_x': The traditional structure function SS in the x direction.
+                'SF_SS_y': The traditional structure function SS in the y direction.
+                'SF_SS_z': The traditional structure function SS in the z direction.
                 'SF_LLL_x': The traditional structure function LLL in the x direction.
                 'SF_LLL_y': The traditional structure function LLL in the y direction.
                 'SF_LLL_z': The traditional structure function LLL in the z direction.
@@ -141,6 +147,15 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                 SF_dict["SF_LL_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u) ** 2
                 )
+            if any("TT" in t for t in sf_type):
+                SF_dict["SF_TT_" + direction] = np.nanmean(
+                    (inputs["v_" + direction + "_shift"] - v) ** 2
+                    + (inputs["w_" + direction + "_shift"] - w) ** 2
+                )
+            if any("SS" in t for t in sf_type):
+                SF_dict["SF_SS_" + direction] = np.nanmean(
+                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
+                )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(
                     (inputs["u_" + direction + "_shift"] - u) ** 3
@@ -161,6 +176,15 @@ def calculate_structure_function_3d(  # noqa: D417, C901
                 SF_dict["SF_LL_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v) ** 2
                 )
+            if any("TT" in t for t in sf_type):
+                SF_dict["SF_TT_" + direction] = np.nanmean(
+                    (inputs["u_" + direction + "_shift"] - u) ** 2
+                    + (inputs["w_" + direction + "_shift"] - w) ** 2
+                )
+            if any("SS" in t for t in sf_type):
+                SF_dict["SF_SS_" + direction] = np.nanmean(
+                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
+                )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(
                     (inputs["v_" + direction + "_shift"] - v) ** 3
@@ -180,6 +204,15 @@ def calculate_structure_function_3d(  # noqa: D417, C901
             if any("LL" in t for t in sf_type):
                 SF_dict["SF_LL_" + direction] = np.nanmean(
                     (inputs["w_" + direction + "_shift"] - w) ** 2
+                )
+            if any("TT" in t for t in sf_type):
+                SF_dict["SF_TT_" + direction] = np.nanmean(
+                    (inputs["u_" + direction + "_shift"] - u) ** 2
+                    + (inputs["v_" + direction + "_shift"] - v) ** 2
+                )
+            if any("SS" in t for t in sf_type):
+                SF_dict["SF_SS_" + direction] = np.nanmean(
+                    (inputs["scalar_" + direction + "_shift"] - scalar) ** 2
                 )
             if any("LLL" in t for t in sf_type):
                 SF_dict["SF_LLL_" + direction] = np.nanmean(

--- a/fluidsf/generate_sf_maps_2d.py
+++ b/fluidsf/generate_sf_maps_2d.py
@@ -36,7 +36,7 @@ def generate_sf_maps_2d(  # noqa: C901, D417
             1D array of y-coordinates.
         sf_type: list
             List of structure function types to calculate. Accepted types are:
-            "ASF_V", "ASF_S", "LL", "LLL", "LTT", "LSS". Defaults to ["ASF_V"].
+            "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to ["ASF_V"].
         scalar: ndarray, optional
             2D array of scalar values. Defaults to None.
         dx: float, optional
@@ -61,6 +61,7 @@ def generate_sf_maps_2d(  # noqa: C901, D417
     adv_scalar = None
     SF_LL = None
     SF_TT = None
+    SF_SS = None
     SF_LLL = None
     SF_LTT = None
     SF_LSS = None
@@ -90,6 +91,8 @@ def generate_sf_maps_2d(  # noqa: C901, D417
         SF_LL = np.zeros([len(x_shifts), len(y_shifts)])
     if any("TT" in t for t in sf_type):
         SF_TT = np.zeros([len(x_shifts), len(y_shifts)])
+    if any("SS" in t for t in sf_type):
+        SF_SS = np.zeros([len(x_shifts), len(y_shifts)])
     if any("LLL" in t for t in sf_type):
         SF_LLL = np.zeros([len(x_shifts), len(y_shifts)])
     if any("LTT" in t for t in sf_type):
@@ -140,6 +143,10 @@ def generate_sf_maps_2d(  # noqa: C901, D417
             ]
         if any("LL" in t for t in sf_type):
             SF_LL[x_shift, y_shift + int(len(y) / 2)] = SF_dicts["SF_LL_xy"]
+        if any("TT" in t for t in sf_type):
+            SF_TT[x_shift, y_shift + int(len(y) / 2)] = SF_dicts["SF_TT_xy"]
+        if any("SS" in t for t in sf_type):
+            SF_SS[x_shift, y_shift + int(len(y) / 2)] = SF_dicts["SF_SS_xy"]
         if any("LLL" in t for t in sf_type):
             SF_LLL[x_shift, y_shift + int(len(y) / 2)] = SF_dicts["SF_LLL_xy"]
         if any("LTT" in t for t in sf_type):
@@ -156,6 +163,7 @@ def generate_sf_maps_2d(  # noqa: C901, D417
         "SF_advection_scalar_xy": SF_scalar_adv,
         "SF_LL_xy": SF_LL,
         "SF_TT_xy": SF_TT,
+        "SF_SS_xy": SF_SS,
         "SF_LLL_xy": SF_LLL,
         "SF_LTT_xy": SF_LTT,
         "SF_LSS_xy": SF_LSS,

--- a/fluidsf/generate_sf_maps_2d.py
+++ b/fluidsf/generate_sf_maps_2d.py
@@ -36,7 +36,8 @@ def generate_sf_maps_2d(  # noqa: C901, D417
             1D array of y-coordinates.
         sf_type: list
             List of structure function types to calculate. Accepted types are:
-            "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to ["ASF_V"].
+            "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
+            ["ASF_V"].
         scalar: ndarray, optional
             2D array of scalar values. Defaults to None.
         dx: float, optional

--- a/fluidsf/generate_structure_functions.py
+++ b/fluidsf/generate_structure_functions.py
@@ -40,7 +40,7 @@ def generate_structure_functions(  # noqa: C901, D417
             1D array of y-coordinates.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". 
+            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS".
             Defaults to "ASF_V".
         scalar: ndarray, optional
             2D array of scalar values. Defaults to None.
@@ -95,12 +95,16 @@ def generate_structure_functions(  # noqa: C901, D417
             "If grid_type is 'latlon', dx and dy must be provided as arrays."
         )
 
-    if scalar is not None and (("SS" not in sf_type) and ("LSS" not in sf_type) 
-                               and ("ASF_S" not in sf_type)):
+    if scalar is not None and (
+        ("SS" not in sf_type) and ("LSS" not in sf_type) and ("ASF_S" not in sf_type)
+    ):
         raise ValueError(
-            "If scalar is provided, you must include 'SS', 'LSS' or 'ASF_S' " "in SF_type."
+            "If scalar is provided, you must include 'SS', 'LSS' or 'ASF_S' "
+            "in SF_type."
         )
-    if scalar is None and (("SS" in sf_type) or ("LSS" in sf_type) or ("ASF_S" in sf_type)):
+    if scalar is None and (
+        ("SS" in sf_type) or ("LSS" in sf_type) or ("ASF_S" in sf_type)
+    ):
         raise ValueError(
             "If you include 'SS', 'LSS' or 'ASF_S' in SF_type, you must provide "
             "a scalar array."

--- a/fluidsf/generate_structure_functions.py
+++ b/fluidsf/generate_structure_functions.py
@@ -40,8 +40,8 @@ def generate_structure_functions(  # noqa: C901, D417
             1D array of y-coordinates.
         sf_type: list
             List of structure function types to calculate.
-            Accepted types are: "ASF_V, "ASF_S", "LL", "LLL", "LTT", "LSS". Defaults to
-            "ASF_V".
+            Accepted types are: "ASF_V, "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". 
+            Defaults to "ASF_V".
         scalar: ndarray, optional
             2D array of scalar values. Defaults to None.
         dx: float, optional
@@ -72,13 +72,13 @@ def generate_structure_functions(  # noqa: C901, D417
     if len(sf_type) == 0:
         raise ValueError(
             "sf_type cannot be an empty list. All elements in sf_type must be strings. "
-            "Accepted strings are: ASF_V, ASF_S, LL, LLL, LTT, LSS."
+            "Accepted strings are: ASF_V, ASF_S, LL, TT, SS, LLL, LTT, LSS."
         )
 
     if not all(isinstance(t, str) for t in sf_type):
         raise ValueError(
             "All elements in sf_type must be strings. Accepted strings are: "
-            "ASF_V, ASF_S, LL, LLL, LTT, LSS."
+            "ASF_V, ASF_S, LL, TT, SS, LLL, LTT, LSS."
         )
 
     if boundary not in ["periodic-all", "periodic-x", "periodic-y", None]:
@@ -95,13 +95,14 @@ def generate_structure_functions(  # noqa: C901, D417
             "If grid_type is 'latlon', dx and dy must be provided as arrays."
         )
 
-    if scalar is not None and (("LSS" not in sf_type) and ("ASF_S" not in sf_type)):
+    if scalar is not None and (("SS" not in sf_type) and ("LSS" not in sf_type) 
+                               and ("ASF_S" not in sf_type)):
         raise ValueError(
-            "If scalar is provided, you must include 'LSS' or 'ASF_S' " "in SF_type."
+            "If scalar is provided, you must include 'SS', 'LSS' or 'ASF_S' " "in SF_type."
         )
-    if scalar is None and (("LSS" in sf_type) or ("ASF_S" in sf_type)):
+    if scalar is None and (("SS" in sf_type) or ("LSS" in sf_type) or ("ASF_S" in sf_type)):
         raise ValueError(
-            "If you include 'LSS' or 'ASF_S' in SF_type, you must provide "
+            "If you include 'SS', 'LSS' or 'ASF_S' in SF_type, you must provide "
             "a scalar array."
         )
 
@@ -115,6 +116,10 @@ def generate_structure_functions(  # noqa: C901, D417
     adv_scalar = None
     SF_x_LL = None
     SF_y_LL = None
+    SF_x_TT = None
+    SF_y_TT = None
+    SF_x_SS = None
+    SF_y_SS = None
     SF_x_LLL = None
     SF_y_LLL = None
     SF_x_LTT = None
@@ -153,6 +158,12 @@ def generate_structure_functions(  # noqa: C901, D417
     if any("LL" in t for t in sf_type):
         SF_x_LL = np.zeros(len(sep_x) + 1)
         SF_y_LL = np.zeros(len(sep_y) + 1)
+    if any("TT" in t for t in sf_type):
+        SF_x_TT = np.zeros(len(sep_x) + 1)
+        SF_y_TT = np.zeros(len(sep_y) + 1)
+    if any("SS" in t for t in sf_type):
+        SF_x_SS = np.zeros(len(sep_x) + 1)
+        SF_y_SS = np.zeros(len(sep_y) + 1)
     if any("LLL" in t for t in sf_type):
         SF_x_LLL = np.zeros(len(sep_x) + 1)
         SF_y_LLL = np.zeros(len(sep_y) + 1)
@@ -188,6 +199,10 @@ def generate_structure_functions(  # noqa: C901, D417
             SF_adv_x[x_shift] = SF_dicts["SF_advection_velocity_x"]
         if any("LL" in t for t in sf_type):
             SF_x_LL[x_shift] = SF_dicts["SF_LL_x"]
+        if any("TT" in t for t in sf_type):
+            SF_x_TT[x_shift] = SF_dicts["SF_TT_x"]
+        if any("SS" in t for t in sf_type):
+            SF_x_SS[x_shift] = SF_dicts["SF_SS_x"]
         if any("LLL" in t for t in sf_type):
             SF_x_LLL[x_shift] = SF_dicts["SF_LLL_x"]
         if any("LTT" in t for t in sf_type):
@@ -226,6 +241,10 @@ def generate_structure_functions(  # noqa: C901, D417
             SF_adv_y[y_shift] = SF_dicts["SF_advection_velocity_y"]
         if any("LL" in t for t in sf_type):
             SF_y_LL[y_shift] = SF_dicts["SF_LL_y"]
+        if any("TT" in t for t in sf_type):
+            SF_y_TT[y_shift] = SF_dicts["SF_TT_y"]
+        if any("SS" in t for t in sf_type):
+            SF_y_SS[y_shift] = SF_dicts["SF_SS_y"]
         if any("LLL" in t for t in sf_type):
             SF_y_LLL[y_shift] = SF_dicts["SF_LLL_y"]
         if any("LTT" in t for t in sf_type):
@@ -251,6 +270,12 @@ def generate_structure_functions(  # noqa: C901, D417
         if any("LL" in t for t in sf_type):
             xd_bin, SF_x_LL = bin_data(xd, SF_x_LL, nbins)
             yd_bin, SF_y_LL = bin_data(yd, SF_y_LL, nbins)
+        if any("TT" in t for t in sf_type):
+            xd_bin, SF_x_TT = bin_data(xd, SF_x_TT, nbins)
+            yd_bin, SF_y_TT = bin_data(yd, SF_y_TT, nbins)
+        if any("SS" in t for t in sf_type):
+            xd_bin, SF_x_SS = bin_data(xd, SF_x_SS, nbins)
+            yd_bin, SF_y_SS = bin_data(yd, SF_y_SS, nbins)
         if any("LLL" in t for t in sf_type):
             xd_bin, SF_x_LLL = bin_data(xd, SF_x_LLL, nbins)
             yd_bin, SF_y_LLL = bin_data(yd, SF_y_LLL, nbins)
@@ -270,6 +295,10 @@ def generate_structure_functions(  # noqa: C901, D417
         "SF_advection_scalar_y": SF_y_scalar,
         "SF_LL_x": SF_x_LL,
         "SF_LL_y": SF_y_LL,
+        "SF_TT_x": SF_x_TT,
+        "SF_TT_y": SF_y_TT,
+        "SF_SS_x": SF_x_SS,
+        "SF_SS_y": SF_y_SS,
         "SF_LLL_x": SF_x_LLL,
         "SF_LLL_y": SF_y_LLL,
         "SF_LTT_x": SF_x_LTT,

--- a/fluidsf/generate_structure_functions_1d.py
+++ b/fluidsf/generate_structure_functions_1d.py
@@ -140,7 +140,7 @@ def generate_structure_functions_1d(  # noqa: C901, D417
             SF_LLL[sep_id] = SF_dicts["SF_LLL"]
         if "LTT" in sf_type:
             SF_LTT[sep_id] = SF_dicts["SF_LTT"]
-        if "LSS" in sf_type:
+        if "LSS" in sf_type and scalar is not None:
             SF_LSS[sep_id] = SF_dicts["SF_LSS"]
 
         # Calculate separation distances along track

--- a/fluidsf/generate_structure_functions_1d.py
+++ b/fluidsf/generate_structure_functions_1d.py
@@ -69,7 +69,7 @@ def generate_structure_functions_1d(  # noqa: C901, D417
             "If grid_type is 'latlon', y must be provided."
             " Ensure x is latitude and y is longitude."
         )
-    if scalar is not None and "SS" not in sf_type:
+    if scalar is not None and "SS" not in sf_type and "LSS" not in sf_type:
         raise ValueError("If scalar is provided, you must include 'SS' and/or 'LSS' in sf_type.")
     if scalar is None and "SS" in sf_type:
         raise ValueError(

--- a/fluidsf/generate_structure_functions_1d.py
+++ b/fluidsf/generate_structure_functions_1d.py
@@ -32,8 +32,8 @@ def generate_structure_functions_1d(  # noqa: C901, D417
             1D array of coordinates. If you have lat-lon data, set x to 1D array of
             latitudes.
         sf_type: list
-            List of structure function types to calculate. Accepted types are: "LL",
-            "LLL", "LTT", "LSS". Defaults to "LLL". If you include "LSS", you must
+            List of structure function types to calculate. Accepted types are: "LL", "TT",
+            "SS", "LLL", "LTT", "LSS". Defaults to "LLL". If you include "SS" or "LSS", you must
             provide a 1D array for scalar.
         v: ndarray
             1D array of v velocity components. Defaults to None.
@@ -69,17 +69,19 @@ def generate_structure_functions_1d(  # noqa: C901, D417
             "If grid_type is 'latlon', y must be provided."
             " Ensure x is latitude and y is longitude."
         )
-    if scalar is not None and "LSS" not in sf_type:
-        raise ValueError("If scalar is provided, you must include 'LSS' in sf_type.")
-    if scalar is None and "LSS" in sf_type:
+    if scalar is not None and "SS" not in sf_type:
+        raise ValueError("If scalar is provided, you must include 'SS' and/or 'LSS' in sf_type.")
+    if scalar is None and "SS" in sf_type:
         raise ValueError(
-            "If you include 'LSS' in sf_type, you must provide a scalar array."
+            "If you include 'SS' or 'LSS' in sf_type, you must provide a scalar array."
         )
-    if v is None and "LTT" in sf_type:
-        raise ValueError("If you include 'LTT' in sf_type, you must provide a v array.")
+    if v is None and "TT" in sf_type:
+        raise ValueError("If you include 'TT' or 'LTT' in sf_type, you must provide a v array.")
 
     # Initialize variables as NoneType
     SF_LL = None
+    SF_TT = None
+    SF_SS = None
     SF_LLL = None
     SF_LTT = None
     SF_LSS = None
@@ -97,6 +99,10 @@ def generate_structure_functions_1d(  # noqa: C901, D417
     # Initialize the structure function arrays
     if "LL" in sf_type:
         SF_LL = np.zeros(len(sep) + 1)
+    if "TT" in sf_type:
+        SF_TT = np.zeros(len(sep) + 1)
+    if "SS" in sf_type:
+        SF_SS = np.zeros(len(sep) + 1)
     if "LLL" in sf_type:
         SF_LLL = np.zeros(len(sep) + 1)
     if "LTT" in sf_type:
@@ -126,6 +132,10 @@ def generate_structure_functions_1d(  # noqa: C901, D417
 
         if "LL" in sf_type:
             SF_LL[sep_id] = SF_dicts["SF_LL"]
+        if "TT" in sf_type:
+            SF_TT[sep_id] = SF_dicts["SF_TT"]
+        if "SS" in sf_type:
+            SF_SS[sep_id] = SF_dicts["SF_SS"]
         if "LLL" in sf_type:
             SF_LLL[sep_id] = SF_dicts["SF_LLL"]
         if "LTT" in sf_type:
@@ -147,6 +157,10 @@ def generate_structure_functions_1d(  # noqa: C901, D417
     if nbins is not None:
         if "LL" in sf_type:
             xd_bin, SF_LL = bin_data(xd, SF_LL, nbins)
+        if "TT" in sf_type:
+            xd_bin, SF_TT = bin_data(xd, SF_TT, nbins)
+        if "SS" in sf_type:
+            xd_bin, SF_SS = bin_data(xd, SF_SS, nbins)
         if "LLL" in sf_type:
             xd_bin, SF_LLL = bin_data(xd, SF_LLL, nbins)
         if "LTT" in sf_type:
@@ -157,6 +171,8 @@ def generate_structure_functions_1d(  # noqa: C901, D417
 
     data = {
         "SF_LL": SF_LL,
+        "SF_TT": SF_TT,
+        "SF_SS": SF_SS,
         "SF_LLL": SF_LLL,
         "SF_LTT": SF_LTT,
         "SF_LSS": SF_LSS,

--- a/fluidsf/generate_structure_functions_1d.py
+++ b/fluidsf/generate_structure_functions_1d.py
@@ -32,9 +32,9 @@ def generate_structure_functions_1d(  # noqa: C901, D417
             1D array of coordinates. If you have lat-lon data, set x to 1D array of
             latitudes.
         sf_type: list
-            List of structure function types to calculate. Accepted types are: "LL", "TT",
-            "SS", "LLL", "LTT", "LSS". Defaults to "LLL". If you include "SS" or "LSS", you must
-            provide a 1D array for scalar.
+            List of structure function types to calculate. Accepted types are: "LL",
+            "TT", "SS", "LLL", "LTT", "LSS". Defaults to "LLL". If you include "SS" or
+            "LSS", you must provide a 1D array for scalar.
         v: ndarray
             1D array of v velocity components. Defaults to None.
         y: ndarray, optional
@@ -70,13 +70,17 @@ def generate_structure_functions_1d(  # noqa: C901, D417
             " Ensure x is latitude and y is longitude."
         )
     if scalar is not None and "SS" not in sf_type and "LSS" not in sf_type:
-        raise ValueError("If scalar is provided, you must include 'SS' and/or 'LSS' in sf_type.")
-    if scalar is None and "SS" in sf_type:
+        raise ValueError(
+            "If scalar is provided, you must include 'SS' and/or 'LSS' in sf_type."
+        )
+    if scalar is None and ("SS" in sf_type or "LSS" in sf_type):
         raise ValueError(
             "If you include 'SS' or 'LSS' in sf_type, you must provide a scalar array."
         )
-    if v is None and "TT" in sf_type:
-        raise ValueError("If you include 'TT' or 'LTT' in sf_type, you must provide a v array.")
+    if v is None and ("TT" in sf_type or "LTT" in sf_type):
+        raise ValueError(
+            "If you include 'TT' or 'LTT' in sf_type, you must provide a v array."
+        )
 
     # Initialize variables as NoneType
     SF_LL = None

--- a/fluidsf/generate_structure_functions_3d.py
+++ b/fluidsf/generate_structure_functions_3d.py
@@ -41,7 +41,7 @@ def generate_structure_functions_3d(  # noqa: C901, D417
             1D array of z-coordinates.
         sf_type: list
             List of structure function types to calculate. Accepted types are:
-            "ASF_V", "ASF_S", "LL", "LLL", "LTT", "LSS". Defaults to ["ASF_V"].
+            "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to ["ASF_V"].
         scalar: ndarray, optional
             3D array of scalar values. Defaults to None.
         boundary: str, optional
@@ -72,6 +72,12 @@ def generate_structure_functions_3d(  # noqa: C901, D417
     SF_x_LL = None
     SF_y_LL = None
     SF_z_LL = None
+    SF_x_TT = None
+    SF_y_TT = None
+    SF_z_TT = None
+    SF_x_SS = None
+    SF_y_SS = None
+    SF_z_SS = None
     SF_x_LLL = None
     SF_y_LLL = None
     SF_z_LLL = None
@@ -120,6 +126,14 @@ def generate_structure_functions_3d(  # noqa: C901, D417
         SF_x_LL = np.zeros(len(sep_x) + 1)
         SF_y_LL = np.zeros(len(sep_y) + 1)
         SF_z_LL = np.zeros(len(sep_z) + 1)
+    if any("TT" in t for t in sf_type):
+        SF_x_TT = np.zeros(len(sep_x) + 1)
+        SF_y_TT = np.zeros(len(sep_y) + 1)
+        SF_z_TT = np.zeros(len(sep_z) + 1)
+    if any("SS" in t for t in sf_type):
+        SF_x_SS = np.zeros(len(sep_x) + 1)
+        SF_y_SS = np.zeros(len(sep_y) + 1)
+        SF_z_SS = np.zeros(len(sep_z) + 1)
     if any("LLL" in t for t in sf_type):
         SF_x_LLL = np.zeros(len(sep_x) + 1)
         SF_y_LLL = np.zeros(len(sep_y) + 1)
@@ -170,6 +184,10 @@ def generate_structure_functions_3d(  # noqa: C901, D417
             SF_x_scalar[x_shift] = SF_dicts["SF_advection_scalar_x"]
         if any("LL" in t for t in sf_type):
             SF_x_LL[x_shift] = SF_dicts["SF_LL_x"]
+        if any("TT" in t for t in sf_type):
+            SF_x_TT[x_shift] = SF_dicts["SF_TT_x"]
+        if any("SS" in t for t in sf_type):
+            SF_x_SS[x_shift] = SF_dicts["SF_SS_x"]
         if any("LLL" in t for t in sf_type):
             SF_x_LLL[x_shift] = SF_dicts["SF_LLL_x"]
         if any("LTT" in t for t in sf_type):
@@ -218,6 +236,10 @@ def generate_structure_functions_3d(  # noqa: C901, D417
             SF_y_scalar[y_shift] = SF_dicts["SF_advection_scalar_y"]
         if any("LL" in t for t in sf_type):
             SF_y_LL[y_shift] = SF_dicts["SF_LL_y"]
+        if any("TT" in t for t in sf_type):
+            SF_y_TT[y_shift] = SF_dicts["SF_TT_y"]
+        if any("SS" in t for t in sf_type):
+            SF_y_SS[y_shift] = SF_dicts["SF_SS_y"]
         if any("LLL" in t for t in sf_type):
             SF_y_LLL[y_shift] = SF_dicts["SF_LLL_y"]
         if any("LTT" in t for t in sf_type):
@@ -266,6 +288,10 @@ def generate_structure_functions_3d(  # noqa: C901, D417
             SF_z_scalar[z_shift] = SF_dicts["SF_advection_scalar_z"]
         if any("LL" in t for t in sf_type):
             SF_z_LL[z_shift] = SF_dicts["SF_LL_z"]
+        if any("TT" in t for t in sf_type):
+            SF_z_TT[z_shift] = SF_dicts["SF_TT_z"]
+        if any("SS" in t for t in sf_type):
+            SF_z_SS[z_shift] = SF_dicts["SF_SS_z"]
         if any("LLL" in t for t in sf_type):
             SF_z_LLL[z_shift] = SF_dicts["SF_LLL_z"]
         if any("LTT" in t for t in sf_type):
@@ -291,6 +317,14 @@ def generate_structure_functions_3d(  # noqa: C901, D417
             xd_bin, SF_x_LL = bin_data(xd, SF_x_LL, nbins)
             yd_bin, SF_y_LL = bin_data(yd, SF_y_LL, nbins)
             zd_bin, SF_z_LL = bin_data(zd, SF_z_LL, nbins)
+        if any("TT" in t for t in sf_type):
+            xd_bin, SF_x_TT = bin_data(xd, SF_x_TT, nbins)
+            yd_bin, SF_y_TT = bin_data(yd, SF_y_TT, nbins)
+            zd_bin, SF_z_TT = bin_data(zd, SF_z_TT, nbins)
+        if any("SS" in t for t in sf_type):
+            xd_bin, SF_x_SS = bin_data(xd, SF_x_SS, nbins)
+            yd_bin, SF_y_SS = bin_data(yd, SF_y_SS, nbins)
+            zd_bin, SF_z_SS = bin_data(zd, SF_z_SS, nbins)
         if any("LLL" in t for t in sf_type):
             xd_bin, SF_x_LLL = bin_data(xd, SF_x_LLL, nbins)
             yd_bin, SF_y_LLL = bin_data(yd, SF_y_LLL, nbins)
@@ -317,6 +351,12 @@ def generate_structure_functions_3d(  # noqa: C901, D417
         "SF_LL_x": SF_x_LL,
         "SF_LL_y": SF_y_LL,
         "SF_LL_z": SF_z_LL,
+        "SF_TT_x": SF_x_TT,
+        "SF_TT_y": SF_y_TT,
+        "SF_TT_z": SF_z_TT,
+        "SF_SS_x": SF_x_SS,
+        "SF_SS_y": SF_y_SS,
+        "SF_SS_z": SF_z_SS,
         "SF_LLL_x": SF_x_LLL,
         "SF_LLL_y": SF_y_LLL,
         "SF_LLL_z": SF_z_LLL,

--- a/fluidsf/generate_structure_functions_3d.py
+++ b/fluidsf/generate_structure_functions_3d.py
@@ -41,7 +41,8 @@ def generate_structure_functions_3d(  # noqa: C901, D417
             1D array of z-coordinates.
         sf_type: list
             List of structure function types to calculate. Accepted types are:
-            "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to ["ASF_V"].
+            "ASF_V", "ASF_S", "LL", "TT", "SS", "LLL", "LTT", "LSS". Defaults to
+            ["ASF_V"].
         scalar: ndarray, optional
             3D array of scalar values. Defaults to None.
         boundary: str, optional


### PR DESCRIPTION
This PR adds second-order transverse and scalar structure functions to the 1D, 2D, and 3D modules, as well as the 2D SF map modules.

For the 3D case, the transverse velocity SF takes into account both of the transverse velocity components consistent with another recent PR.