### PR TITLE
Renamed 2D functions to include "_2d" in name

### DIFF
--- a/fluidsf/__init__.py
+++ b/fluidsf/__init__.py
@@ -4,17 +4,17 @@ This package calculates structure functions from ocean velocity data.
 """
 
 from .bin_data import bin_data
-from .calculate_advection import calculate_advection
+from .calculate_advection_2d import calculate_advection_2d
 from .calculate_advection_3d import calculate_advection_3d
 from .calculate_separation_distances import calculate_separation_distances
 from .calculate_separation_distances_3d import calculate_separation_distances_3d
 from .calculate_sf_maps_2d import calculate_sf_maps_2d
-from .calculate_structure_function import calculate_structure_function
 from .calculate_structure_function_1d import calculate_structure_function_1d
+from .calculate_structure_function_2d import calculate_structure_function_2d
 from .calculate_structure_function_3d import calculate_structure_function_3d
 from .generate_sf_maps_2d import generate_sf_maps_2d
-from .generate_structure_functions import generate_structure_functions
 from .generate_structure_functions_1d import generate_structure_functions_1d
+from .generate_structure_functions_2d import generate_structure_functions_2d
 from .generate_structure_functions_3d import generate_structure_functions_3d
 from .shift_array_1d import shift_array_1d
 from .shift_array_2d import shift_array_2d
@@ -22,14 +22,14 @@ from .shift_array_3d import shift_array_3d
 
 __all__ = (
     "generate_sf_maps_2d",
-    "generate_structure_functions",
     "generate_structure_functions_1d",
+    "generate_structure_functions_2d",
     "generate_structure_functions_3d",
     "calculate_sf_maps_2d",
-    "calculate_structure_function",
     "calculate_structure_function_1d",
+    "calculate_structure_function_2d",
     "calculate_structure_function_3d",
-    "calculate_advection",
+    "calculate_advection_2d",
     "calculate_advection_3d",
     "calculate_separation_distances",
     "calculate_separation_distances_3d",

--- a/fluidsf/calculate_advection_2d.py
+++ b/fluidsf/calculate_advection_2d.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def calculate_advection(  # noqa: D417
+def calculate_advection_2d(  # noqa: D417
     u,
     v,
     x,

--- a/fluidsf/calculate_structure_function_2d.py
+++ b/fluidsf/calculate_structure_function_2d.py
@@ -3,7 +3,7 @@ import numpy as np
 from .shift_array_2d import shift_array_2d
 
 
-def calculate_structure_function(  # noqa: D417, C901
+def calculate_structure_function_2d(  # noqa: D417, C901
     u,
     v,
     adv_x,

--- a/fluidsf/generate_sf_maps_2d.py
+++ b/fluidsf/generate_sf_maps_2d.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from .calculate_advection import calculate_advection
+from .calculate_advection_2d import calculate_advection_2d
 from .calculate_sf_maps_2d import calculate_sf_maps_2d
 
 
@@ -84,10 +84,10 @@ def generate_sf_maps_2d(  # noqa: C901, D417
 
     if any("ASF_V" in t for t in sf_type):
         SF_adv = np.zeros([len(x_shifts), len(y_shifts)])
-        adv_x, adv_y = calculate_advection(u, v, x, y, dx, dy, grid_type)
+        adv_x, adv_y = calculate_advection_2d(u, v, x, y, dx, dy, grid_type)
     if any("ASF_S" in t for t in sf_type):
         SF_scalar_adv = np.zeros([len(x_shifts), len(y_shifts)])
-        adv_scalar = calculate_advection(u, v, x, y, dx, dy, grid_type, scalar)
+        adv_scalar = calculate_advection_2d(u, v, x, y, dx, dy, grid_type, scalar)
     if any("LL" in t for t in sf_type):
         SF_LL = np.zeros([len(x_shifts), len(y_shifts)])
     if any("TT" in t for t in sf_type):

--- a/fluidsf/generate_structure_functions_2d.py
+++ b/fluidsf/generate_structure_functions_2d.py
@@ -1,15 +1,15 @@
 import numpy as np
 
 from .bin_data import bin_data
-from .calculate_advection import calculate_advection
+from .calculate_advection_2d import calculate_advection_2d
 from .calculate_separation_distances import calculate_separation_distances
-from .calculate_structure_function import (
-    calculate_structure_function,
+from .calculate_structure_function_2d import (
+    calculate_structure_function_2d,
 )
 from .shift_array_1d import shift_array_1d
 
 
-def generate_structure_functions(  # noqa: C901, D417
+def generate_structure_functions_2d(  # noqa: C901, D417
     u,
     v,
     x,
@@ -154,11 +154,11 @@ def generate_structure_functions(  # noqa: C901, D417
     if any("ASF_V" in t for t in sf_type):
         SF_adv_x = np.zeros(len(sep_x) + 1)
         SF_adv_y = np.zeros(len(sep_y) + 1)
-        adv_x, adv_y = calculate_advection(u, v, x, y, dx, dy, grid_type)
+        adv_x, adv_y = calculate_advection_2d(u, v, x, y, dx, dy, grid_type)
     if any("ASF_S" in t for t in sf_type):
         SF_x_scalar = np.zeros(len(sep_x) + 1)
         SF_y_scalar = np.zeros(len(sep_y) + 1)
-        adv_scalar = calculate_advection(u, v, x, y, dx, dy, grid_type, scalar)
+        adv_scalar = calculate_advection_2d(u, v, x, y, dx, dy, grid_type, scalar)
     if any("LL" in t for t in sf_type):
         SF_x_LL = np.zeros(len(sep_x) + 1)
         SF_y_LL = np.zeros(len(sep_y) + 1)
@@ -186,7 +186,7 @@ def generate_structure_functions(  # noqa: C901, D417
         else:
             xroll = shift_array_1d(x, shift_by=x_shift, boundary=None)
 
-        SF_dicts = calculate_structure_function(
+        SF_dicts = calculate_structure_function_2d(
             u,
             v,
             adv_x,
@@ -228,7 +228,7 @@ def generate_structure_functions(  # noqa: C901, D417
         else:
             yroll = shift_array_1d(y, shift_by=y_shift, boundary=None)
 
-        SF_dicts = calculate_structure_function(
+        SF_dicts = calculate_structure_function_2d(
             u,
             v,
             adv_x,

--- a/tests/test_calculate_advection_2d.py
+++ b/tests/test_calculate_advection_2d.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from fluidsf.calculate_advection import calculate_advection
+from fluidsf.calculate_advection_2d import calculate_advection_2d
 
 
 @pytest.mark.parametrize(
@@ -165,5 +165,5 @@ def test_calculate_advection(
     u, v, x, y, dx, dy, grid_type, scalar, expected_advection_result
 ):
     """Test that calculate_advection works correctly for multiple cases."""
-    output_advection = calculate_advection(u, v, x, y, dx, dy, grid_type, scalar)
+    output_advection = calculate_advection_2d(u, v, x, y, dx, dy, grid_type, scalar)
     np.testing.assert_allclose(output_advection, expected_advection_result)

--- a/tests/test_calculate_structure_function_2d.py
+++ b/tests/test_calculate_structure_function_2d.py
@@ -177,7 +177,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_x
+            )[
+                1
+            ],  # adv_x
             np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
@@ -186,7 +188,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_y
+            )[
+                1
+            ],  # adv_y
             1,  # shift_x
             1,  # shift_y
             ["ASF_V", "LL", "LLL", "LTT"],  # sf_type
@@ -216,7 +220,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_x
+            )[
+                1
+            ],  # adv_x
             np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
@@ -225,7 +231,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_y
+            )[
+                1
+            ],  # adv_y
             1,  # shift_x
             1,  # shift_y
             ["ASF_V"],  # sf_type
@@ -249,7 +257,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_x
+            )[
+                1
+            ],  # adv_x
             np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
@@ -258,7 +268,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_y
+            )[
+                1
+            ],  # adv_y
             1,  # shift_x
             1,  # shift_y
             ["ASF_V", "ASF_S", "LL", "LLL", "LTT", "LSS"],  # sf_type
@@ -271,7 +283,9 @@ from fluidsf.calculate_structure_function_2d import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[1],  # adv_scalar
+            )[
+                1
+            ],  # adv_scalar
             None,  # boundary
             {
                 "SF_advection_velocity_x": (5 / 4) * 1,

--- a/tests/test_calculate_structure_function_2d.py
+++ b/tests/test_calculate_structure_function_2d.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from fluidsf.calculate_structure_function import calculate_structure_function
+from fluidsf.calculate_structure_function_2d import calculate_structure_function_2d
 
 
 @pytest.mark.parametrize(
@@ -177,9 +177,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_x
+            )[1],  # adv_x
             np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
@@ -188,9 +186,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_y
+            )[1],  # adv_y
             1,  # shift_x
             1,  # shift_y
             ["ASF_V", "LL", "LLL", "LTT"],  # sf_type
@@ -220,9 +216,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_x
+            )[1],  # adv_x
             np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
@@ -231,9 +225,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_y
+            )[1],  # adv_y
             1,  # shift_x
             1,  # shift_y
             ["ASF_V"],  # sf_type
@@ -257,9 +249,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_x
+            )[1],  # adv_x
             np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
@@ -268,9 +258,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 0.5 * np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_y
+            )[1],  # adv_y
             1,  # shift_x
             1,  # shift_y
             ["ASF_V", "ASF_S", "LL", "LLL", "LTT", "LSS"],  # sf_type
@@ -283,9 +271,7 @@ from fluidsf.calculate_structure_function import calculate_structure_function
             * np.meshgrid(np.arange(10), np.arange(10))[0]
             * np.gradient(
                 np.meshgrid(np.arange(10), np.arange(10))[0], 1, 1, axis=(1, 0)
-            )[
-                1
-            ],  # adv_scalar
+            )[1],  # adv_scalar
             None,  # boundary
             {
                 "SF_advection_velocity_x": (5 / 4) * 1,
@@ -438,7 +424,7 @@ def test_calculate_structure_function_parameterized(
     expected_result,
 ):
     """Test that calculate_structure_function works correctly for multiple cases."""
-    output_dict = calculate_structure_function(
+    output_dict = calculate_structure_function_2d(
         u,
         v,
         adv_x,

--- a/tests/test_generate_structure_functions_2d.py
+++ b/tests/test_generate_structure_functions_2d.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from geopy.distance import great_circle
 
-from fluidsf.generate_structure_functions import generate_structure_functions
+from fluidsf.generate_structure_functions_2d import generate_structure_functions_2d
 
 
 @pytest.mark.parametrize(
@@ -509,7 +509,7 @@ def test_generate_structure_functions_parameterized(
     """Test generate_structure_functions produces expected results."""
     if expected_dict == ValueError:
         with pytest.raises(ValueError):
-            generate_structure_functions(
+            generate_structure_functions_2d(
                 u,
                 v,
                 x,
@@ -524,7 +524,7 @@ def test_generate_structure_functions_parameterized(
             )
         return
     else:
-        output_dict = generate_structure_functions(
+        output_dict = generate_structure_functions_2d(
             u,
             v,
             x,


### PR DESCRIPTION
Quick PR to update functions like `generate_structure_functions()` to `generate_structure_functions_2d()` to be consistent with 1D, 2D, 3D naming conventions. Ready to merge assuming tests pass.