### PR TITLE
49 remove nones from the return dictionaries

### DIFF
--- a/src/fluidsf/generate_sf_maps_2d.py
+++ b/src/fluidsf/generate_sf_maps_2d.py
@@ -160,17 +160,21 @@ def generate_sf_maps_2d(  # noqa: C901, D417
     # most negative towards zero, since new_array[-n] writes to the n-th from last index
 
     data = {
-        "SF_advection_velocity_xy": SF_adv,
-        "SF_advection_scalar_xy": SF_scalar_adv,
-        "SF_LL_xy": SF_LL,
-        "SF_TT_xy": SF_TT,
-        "SF_SS_xy": SF_SS,
-        "SF_LLL_xy": SF_LLL,
-        "SF_LTT_xy": SF_LTT,
-        "SF_LSS_xy": SF_LSS,
-        "separation_distances": separation_distances,
-        "separation_angles": separation_angles,
-        "x_separations": x_separations,
-        "y_separations": y_separations,
+        key: value
+        for key, value in {
+            "SF_advection_velocity_xy": SF_adv,
+            "SF_advection_scalar_xy": SF_scalar_adv,
+            "SF_LL_xy": SF_LL,
+            "SF_TT_xy": SF_TT,
+            "SF_SS_xy": SF_SS,
+            "SF_LLL_xy": SF_LLL,
+            "SF_LTT_xy": SF_LTT,
+            "SF_LSS_xy": SF_LSS,
+            "separation_distances": separation_distances,
+            "separation_angles": separation_angles,
+            "x_separations": x_separations,
+            "y_separations": y_separations,
+            }.items()
+        if value is not None
     }
     return data

--- a/src/fluidsf/generate_structure_functions_1d.py
+++ b/src/fluidsf/generate_structure_functions_1d.py
@@ -176,14 +176,14 @@ def generate_structure_functions_1d(  # noqa: C901, D417
     data = {
         key: value
         for key, value in {
-        "SF_LL": SF_LL,
-        "SF_TT": SF_TT,
-        "SF_SS": SF_SS,
-        "SF_LLL": SF_LLL,
-        "SF_LTT": SF_LTT,
-        "SF_LSS": SF_LSS,
-        "x-diffs": xd,
-        }.items()
+            "SF_LL": SF_LL,
+            "SF_TT": SF_TT,
+            "SF_SS": SF_SS,
+            "SF_LLL": SF_LLL,
+            "SF_LTT": SF_LTT,
+            "SF_LSS": SF_LSS,
+            "x-diffs": xd,
+            }.items()
         if value is not None
     }
     return data


### PR DESCRIPTION
Missed one file when addressing #49, now all four generate modules, including SF maps, strip Nones in the returned dictionaries. 