### PR TITLE
Save memory in calculation loop

### DIFF
--- a/src/fluidsf/generate_structure_functions_nd.py
+++ b/src/fluidsf/generate_structure_functions_nd.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 
+
 def compute_LLL(
     ds,
     shiftby,
@@ -60,25 +61,23 @@ def compute_LLL(
         # The shifting list comp is doing all the heavy lifting in terms of iteration, 
         # so it would also be a bottle neck. Supplying a pre-chunked dataset should help
         # at this point, but there might be better options. 
-        sf_results = [
-            (
+        LLL_lst = []
+        for shift_i in shift_values:
+            sf_results = (
                 ds[U_i].roll({X_i: int(shift_i)}, roll_coords=False)
                 if periodic_i
                 else ds[U_i].shift({X_i: int(shift_i)})
             )
-            for shift_i in shift_values
-        ]
-
+            LLL_lst.append(
+                ((ds[U_i] - sf_results) ** 3)
+                .mean(dim=avg_dim)
+                .expand_dims(shiftby=[shift_i])
+            )
         # Just reformatting the results of the list comp into a dataset with a new 
         # shiftby dimension. Since we call a mean here, this might take longer if 
         # the initial dataset is not already chunked.
         ds_LLL[f"SF_{U_i}{U_i}{U_i}"] = xr.concat(
-            [
-                ((ds[U_i] - shifted) ** 3).mean(dim=avg_dim).expand_dims(
-                    shiftby=[shift_i]
-                )
-                for shifted, shift_i in zip(sf_results, shift_values, strict=False)
-            ],
+            LLL_lst,
             dim="shiftby",
         ).assign_coords(shiftby=shift_values)
 

--- a/src/fluidsf/generate_structure_functions_nd.py
+++ b/src/fluidsf/generate_structure_functions_nd.py
@@ -62,6 +62,7 @@ def compute_LLL(
         # so it would also be a bottle neck. Supplying a pre-chunked dataset should help
         # at this point, but there might be better options. 
         LLL_lst = []
+        dx_lst = []
         for shift_i in shift_values:
             sf_results = (
                 ds[U_i].roll({X_i: int(shift_i)}, roll_coords=False)
@@ -73,12 +74,13 @@ def compute_LLL(
                 .mean(dim=avg_dim)
                 .expand_dims(shiftby=[shift_i])
             )
+            dx_lst.append(float(ds[X_i][int(shift_i)] - ds[X_i][0]))
         # Just reformatting the results of the list comp into a dataset with a new 
         # shiftby dimension. Since we call a mean here, this might take longer if 
         # the initial dataset is not already chunked.
         ds_LLL[f"SF_{U_i}{U_i}{U_i}"] = xr.concat(
             LLL_lst,
             dim="shiftby",
-        ).assign_coords(shiftby=shift_values)
+        ).assign_coords(shiftby=np.atleast_1d(dx_lst))
 
     return ds_LLL


### PR DESCRIPTION
Compute SF and discard each shifted array, rather than saving all shifted arrays in the outer loop. Saves memory for large datasets, particularly relevant on a GPU.